### PR TITLE
Separate documentation example templates.

### DIFF
--- a/generators/config/index.js
+++ b/generators/config/index.js
@@ -10,17 +10,17 @@ module.exports = yeoman.generators.Base.extend(_.extend(base.generator,{
 
   location: 'configs',
 
-  files: ['colors', 'icons', 'images', 'layouts', 'typography'],
+  stylesheets: ['colors', 'icons', 'images', 'layouts', 'typography'],
 
   configuring: function () {
-    this.filePaths = this.files.map(function(file) {
+    this.filePaths = this.stylesheets.map(function(file) {
       return {
         dest: this.location + '/' + this.name + '/_' + file + '.scss',
         src: '_' + file + '.scss'
       };
     }.bind(this));
 
-    this.importPaths = this.files.map(function(file) {
+    this.importPaths = this.stylesheets.map(function(file) {
       return '../' + this.location + '/' + this.name + '/' + file;
     }.bind(this));
   }

--- a/generators/core/index.js
+++ b/generators/core/index.js
@@ -10,17 +10,17 @@ module.exports = yeoman.generators.Base.extend(_.extend(base.generator,{
 
   location: 'core',
 
-  files: ['reset', 'base'],
+  stylesheets: ['reset', 'base'],
 
   configuring: function () {
-    this.filePaths = this.files.map(function(file) {
+    this.filePaths = this.stylesheets.map(function(file) {
       return {
         dest: this.location + '/_' + file + '.scss',
         src: '_' + file + '.scss'
       };
     }.bind(this));
 
-    this.importPaths = this.files.map(function(file) {
+    this.importPaths = this.stylesheets.map(function(file) {
       return '../' + this.location + '/' + file;
     }.bind(this));
   }

--- a/generators/export/index.js
+++ b/generators/export/index.js
@@ -9,7 +9,7 @@ module.exports = yeoman.generators.Base.extend({
 
   location: 'exports',
 
-  files: ['export'],
+  stylesheets: ['export'],
 
   initializing: function () {
     this.argument('name', {
@@ -28,7 +28,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   configuring: function () {
-    this.filePaths = this.files.map(function(file) {
+    this.filePaths = this.stylesheets.map(function(file) {
       return {
         dest: this.location + '/' + this.name + '.scss',
         src: '_' + file + '.scss'

--- a/generators/function/index.js
+++ b/generators/function/index.js
@@ -10,17 +10,17 @@ module.exports = yeoman.generators.Base.extend(_.extend(base.generator,{
 
   location: 'functions',
 
-  files: ['function'],
+  stylesheets: ['function'],
 
   configuring: function () {
-    this.filePaths = this.files.map(function(file) {
+    this.filePaths = this.stylesheets.map(function(file) {
       return {
         dest: 'helpers/' + this.location + '/_' + this.name + '.scss',
         src: '_' + file + '.scss'
       };
     }.bind(this));
 
-    this.importPaths = this.files.map(function(file) {
+    this.importPaths = this.stylesheets.map(function(file) {
       return '../helpers/' + this.location + '/' + this.name;
     }.bind(this));
   }

--- a/generators/hotfix/index.js
+++ b/generators/hotfix/index.js
@@ -10,17 +10,17 @@ module.exports = yeoman.generators.Base.extend(_.extend(base.generator,{
 
   location: 'hotfixes',
 
-  files: ['hotfix'],
+  stylesheets: ['hotfix'],
 
   configuring: function () {
-    this.filePaths = this.files.map(function(file) {
+    this.filePaths = this.stylesheets.map(function(file) {
       return {
         dest: this.location + '/_' + this.name + '.scss',
         src: '_' + file + '.scss'
       };
     }.bind(this));
 
-    this.importPaths = this.files.map(function(file) {
+    this.importPaths = this.stylesheets.map(function(file) {
       return '../' + this.location + '/' + this.name;
     }.bind(this));
   }

--- a/generators/layout/index.js
+++ b/generators/layout/index.js
@@ -10,17 +10,17 @@ module.exports = yeoman.generators.Base.extend(_.extend(base.generator,{
 
   location: 'layouts',
 
-  files: ['layout'],
+  stylesheets: ['layout'],
 
   configuring: function () {
-    this.filePaths = this.files.map(function(file) {
+    this.filePaths = this.stylesheets.map(function(file) {
       return {
         dest: this.location + '/_' + this.name + '.scss',
         src: '_' + file + '.scss'
       };
     }.bind(this));
 
-    this.importPaths = this.files.map(function(file) {
+    this.importPaths = this.stylesheets.map(function(file) {
       return '../' + this.location + '/' + this.name;
     }.bind(this));
   }

--- a/generators/mixin/index.js
+++ b/generators/mixin/index.js
@@ -10,17 +10,17 @@ module.exports = yeoman.generators.Base.extend(_.extend(base.generator,{
 
   location: 'mixins',
 
-  files: ['mixin'],
+  stylesheets: ['mixin'],
 
   configuring: function () {
-    this.filePaths = this.files.map(function(file) {
+    this.filePaths = this.stylesheets.map(function(file) {
       return {
         dest: 'helpers/' + this.location + '/_' + this.name + '.scss',
         src: '_' + file + '.scss'
       };
     }.bind(this));
 
-    this.importPaths = this.files.map(function(file) {
+    this.importPaths = this.stylesheets.map(function(file) {
       return '../helpers/' + this.location + '/' + this.name;
     }.bind(this));
   }

--- a/generators/module/index.js
+++ b/generators/module/index.js
@@ -10,18 +10,29 @@ module.exports = yeoman.generators.Base.extend(_.extend(base.generator,{
 
   location: 'modules',
 
-  files: ['base', 'layout', 'modifier', 'state', 'theme'],
+  stylesheets: ['base', 'layout', 'modifier', 'state', 'theme'],
+
+  templates: ['template'],
 
   configuring: function () {
-    this.filePaths = this.files.map(function(file) {
+    this.stylesheetPaths = this.stylesheets.map(function(file) {
       return {
         dest: this.location + '/' + this.name + '/_' + file + '.scss',
         src: '_' + file + '.scss'
       };
     }.bind(this));
 
-    this.importPaths = this.files.map(function(file) {
+    this.templatePaths = this.templates.map(function(file) {
+      return {
+        dest: this.location + '/' + this.name + '/templates/example.hbs',
+        src: 'templates/_' + file + '.hbs'
+      };
+    }.bind(this));
+
+    this.importPaths = this.stylesheets.map(function(file) {
       return '../' + this.location + '/' + this.name + '/' + file;
     }.bind(this));
+
+    this.filePaths = this.stylesheetPaths.concat( this.templatePaths );
   }
 }));

--- a/generators/module/templates/_base.scss
+++ b/generators/module/templates/_base.scss
@@ -4,9 +4,6 @@
 //
 // .<%= name %> - base <%= name %> class.
 //
-// Markup:
-// <div class="<%= name %> {{modifier_class}}">
-//   <%= name %> content.
-// </div>
+// Markup: templates/example.hbs
 //
 // Styleguide modules.<%= name %>

--- a/generators/module/templates/_layout.scss
+++ b/generators/module/templates/_layout.scss
@@ -4,9 +4,6 @@
 //
 // .<%= name %>-l-* - layout class description.
 //
-// Markup:
-// <div class="<%= name %> {{modifier_class}}">
-//   <%= name %> content.
-// </div>
+// Markup: templates/example.hbs
 //
 // Styleguide modules.<%= name %>.layout

--- a/generators/module/templates/_modifier.scss
+++ b/generators/module/templates/_modifier.scss
@@ -4,9 +4,6 @@
 //
 // .<%= name %>-m-* - modifier class description.
 //
-// Markup:
-// <div class="<%= name %> {{modifier_class}}">
-//   <%= name %> content.
-// </div>
+// Markup: templates/example.hbs
 //
 // Styleguide modules.<%= name %>.modifier

--- a/generators/module/templates/_state.scss
+++ b/generators/module/templates/_state.scss
@@ -4,9 +4,6 @@
 //
 // .<%= name %>-s-* - state class description.
 //
-// Markup:
-// <div class="<%= name %> {{modifier_class}}">
-//   <%= name %> content.
-// </div>
+// Markup: templates/example.hbs
 //
 // Styleguide modules.<%= name %>.state

--- a/generators/module/templates/_theme.scss
+++ b/generators/module/templates/_theme.scss
@@ -4,9 +4,6 @@
 //
 // .<%= name %>-t-* - theme class description.
 //
-// Markup:
-// <div class="<%= name %> {{modifier_class}}">
-//   <%= name %> content.
-// </div>
+// Markup: templates/example.hbs
 //
 // Styleguide modules.<%= name %>.theme

--- a/generators/module/templates/templates/_template.hbs
+++ b/generators/module/templates/templates/_template.hbs
@@ -1,0 +1,3 @@
+<div class="<%= name %> {{modifier_class}}">
+  <%= name %> content.
+</div>

--- a/generators/page/index.js
+++ b/generators/page/index.js
@@ -10,17 +10,17 @@ module.exports = yeoman.generators.Base.extend(_.extend(base.generator,{
 
   location: 'pages',
 
-  files: ['page'],
+  stylesheets: ['page'],
 
   configuring: function () {
-    this.filePaths = this.files.map(function(file) {
+    this.filePaths = this.stylesheets.map(function(file) {
       return {
         dest: this.location + '/_' + this.name + '.scss',
         src: '_' + file + '.scss'
       };
     }.bind(this));
 
-    this.importPaths = this.files.map(function(file) {
+    this.importPaths = this.stylesheets.map(function(file) {
       return '../' + this.location + '/' + this.name;
     }.bind(this));
   }

--- a/generators/unit/index.js
+++ b/generators/unit/index.js
@@ -17,7 +17,7 @@ module.exports = yeoman.generators.Base.extend(_.extend(base.generator,{
   configuring: function () {
     this.stylesheetPaths = this.stylesheets.map(function(file) {
       return {
-        dest: this.location + '/' + this.name + '/_' + file + '.scss',
+        dest: this.location + '/' + this.name + '/_' + this.name + '.scss',
         src: '_' + file + '.scss'
       };
     }.bind(this));

--- a/generators/unit/index.js
+++ b/generators/unit/index.js
@@ -10,18 +10,29 @@ module.exports = yeoman.generators.Base.extend(_.extend(base.generator,{
 
   location: 'units',
 
-  files: ['unit'],
+  stylesheets: ['unit'],
+
+  templates: ['template'],
 
   configuring: function () {
-    this.filePaths = this.files.map(function(file) {
+    this.stylesheetPaths = this.stylesheets.map(function(file) {
       return {
-        dest: this.location + '/_' + this.name + '.scss',
+        dest: this.location + '/' + this.name + '/_' + file + '.scss',
         src: '_' + file + '.scss'
       };
     }.bind(this));
 
-    this.importPaths = this.files.map(function(file) {
-      return '../' + this.location + '/' + this.name;
+    this.templatePaths = this.templates.map(function(file) {
+      return {
+        dest: this.location + '/' + this.name + '/templates/example.hbs',
+        src: 'templates/_' + file + '.hbs'
+      };
     }.bind(this));
+
+    this.importPaths = this.stylesheets.map(function(file) {
+      return '../' + this.location + '/' + this.name + '/' + file;
+    }.bind(this));
+
+    this.filePaths = this.stylesheetPaths.concat(this.templatePaths);
   }
 }));

--- a/generators/unit/templates/_unit.scss
+++ b/generators/unit/templates/_unit.scss
@@ -2,9 +2,6 @@
 //
 // classes for the <%= name %> unit.
 //
-// Markup:
-// <div class="<%= name %>">
-//   <%= name %> content.
-// </div>
+// Markup: templates/example.hbs
 //
 // Styleguide units.<%= name %>

--- a/generators/unit/templates/templates/_template.hbs
+++ b/generators/unit/templates/templates/_template.hbs
@@ -1,0 +1,3 @@
+<div class="<%= name %>">
+  <%= name %> content.
+</div>

--- a/generators/vendor/index.js
+++ b/generators/vendor/index.js
@@ -10,17 +10,17 @@ module.exports = yeoman.generators.Base.extend(_.extend(base.generator,{
 
   location: 'vendors',
 
-  files: ['vendor'],
+  stylesheets: ['vendor'],
 
   configuring: function () {
-    this.filePaths = this.files.map(function(file) {
+    this.filePaths = this.stylesheets.map(function(file) {
       return {
         dest: this.location + '/_' + this.name + '.scss',
         src: '_' + file + '.scss'
       };
     }.bind(this));
 
-    this.importPaths = this.files.map(function(file) {
+    this.importPaths = this.stylesheets.map(function(file) {
       return '../' + this.location + '/' + this.name;
     }.bind(this));
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-plum",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Yeoman generator for plum.",
   "license": "MIT",
   "repository": "plum-css/generator-plum",

--- a/test/test-module.js
+++ b/test/test-module.js
@@ -22,7 +22,8 @@ describe('Plum:module', function () {
       'modules/default/_layout.scss',
       'modules/default/_modifier.scss',
       'modules/default/_state.scss',
-      'modules/default/_theme.scss'
+      'modules/default/_theme.scss',
+      'modules/default/templates/example.hbs'
     ]);
   });
 });

--- a/test/test-unit.js
+++ b/test/test-unit.js
@@ -18,7 +18,8 @@ describe('Plum:unit', function () {
 
   it('creates files', function () {
     assert.file([
-      'units/default/_default.scss'
+      'units/default/_default.scss',
+      'units/default/templates/example.hbs'
     ]);
   });
 });

--- a/test/test-unit.js
+++ b/test/test-unit.js
@@ -18,7 +18,7 @@ describe('Plum:unit', function () {
 
   it('creates files', function () {
     assert.file([
-      'units/_default.scss'
+      'units/default/_default.scss'
     ]);
   });
 });


### PR DESCRIPTION
Instead of inlining the documentation markup examples for modules and units, this will create and use a separate template located in templates/examples/.
